### PR TITLE
Do not  show error message if using custom theme.

### DIFF
--- a/lua/chameleon/utils.lua
+++ b/lua/chameleon/utils.lua
@@ -19,7 +19,7 @@ M.get_theme_tb = function(type)
     return default_theme[type]
   else
     -- Otherwise, throw an error indicating that the theme does not exist
-    error('No such theme!')
+    error()
   end
 end
 


### PR DESCRIPTION
The error message gets in the way every time neovim is opened if using a custom theme.